### PR TITLE
Fix custom rules/user order

### DIFF
--- a/src/modulesOrder.ts
+++ b/src/modulesOrder.ts
@@ -20,9 +20,19 @@ export default class ModulesOrder {
     }
 
     check(path: string): boolean {
-        const index = this.importGroups
+        let index = this.importGroups
             .slice(this.groupIndex)
             .findIndex(item => item.check(path));
+
+        if (this.importGroups[this.groupIndex + index].type === ModuleType.User) {
+            let anotherIndex = this.importGroups
+                .slice(this.groupIndex + index + 1)
+                .findIndex(item => item.check(path)); // look ahead to check if there are more specific cases
+
+            if (anotherIndex >= 0) {
+                index += anotherIndex;
+            }
+        }
 
         if (index === -1) {
             return false;

--- a/src/modulesOrder.ts
+++ b/src/modulesOrder.ts
@@ -30,7 +30,7 @@ export default class ModulesOrder {
                 .findIndex(item => item.check(path)); // look ahead to check if there are more specific cases
 
             if (anotherIndex >= 0) {
-                index += anotherIndex;
+                index += anotherIndex + 1;
             }
         }
 

--- a/test/rules/multiple-custom-groups/test.ts.lint
+++ b/test/rules/multiple-custom-groups/test.ts.lint
@@ -1,0 +1,17 @@
+import { A, B, C }  from 'lib1';
+
+import * as bar from './a';
+import {
+    V,
+    B
+} from './b';
+
+import Cl1_correct_order from './testcustom1';
+
+import Cl1_correct_order from './testcustom2';
+
+
+import Cl2_wrong_order from './testcustom2';
+
+import Cl2_wrong_order from './testcustom1';
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ["Custom import /testcustom1/" must be higher than "Custom import /testcustom2/"]

--- a/test/rules/multiple-custom-groups/tslint.json
+++ b/test/rules/multiple-custom-groups/tslint.json
@@ -1,0 +1,15 @@
+{
+  "rulesDirectory": "../../../dist",
+  "rules": {
+    "origin-ordered-imports": [ 
+      true, 
+      "one-blank-line",
+      [
+        "lib",
+        "user",
+        "testcustom1",
+        "testcustom2"
+      ]
+    ]
+  }
+}

--- a/test/rules/multiple-custom-groups2/test.ts.lint
+++ b/test/rules/multiple-custom-groups2/test.ts.lint
@@ -1,8 +1,8 @@
 import { A, B, C }  from 'lib1';
 
-import Cl1_correct_order from './testcustom1';
+import Cl1 from './testcustom1';
 
 import * as bar from './a';
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~ ["User import" must be higher than "Custom import /testcustom1/"]
 
-import Cl1_correct_order from './testcustom2';
+import Cl1 from './testcustom2';

--- a/test/rules/multiple-custom-groups2/test.ts.lint
+++ b/test/rules/multiple-custom-groups2/test.ts.lint
@@ -1,0 +1,8 @@
+import { A, B, C }  from 'lib1';
+
+import Cl1_correct_order from './testcustom1';
+
+import * as bar from './a';
+~~~~~~~~~~~~~~~~~~~~~~~~~~~ ["User import" must be higher than "Custom import /testcustom1/"]
+
+import Cl1_correct_order from './testcustom2';

--- a/test/rules/multiple-custom-groups2/tslint.json
+++ b/test/rules/multiple-custom-groups2/tslint.json
@@ -1,0 +1,15 @@
+{
+  "rulesDirectory": "../../../dist",
+  "rules": {
+    "origin-ordered-imports": [ 
+      true, 
+      "one-blank-line",
+      [
+        "lib",
+        "user",
+        "testcustom1",
+        "testcustom2"
+      ]
+    ]
+  }
+}


### PR DESCRIPTION
Added check for custom rule if import path matched `user`. It fixes ordering issues, there are some new tests with examples of such cases